### PR TITLE
Detect crash inside worker and reject promise

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -64,7 +64,7 @@ impl Thread {
 
                     // This overrides `self.onmessage`
                     const _worker = wbg.wmt_bootstrap(self, id);
-
+                    
                     self.wmtContext = { wbg, wasm, _worker };
                     // console.log('bootstrap complete - self.wmtContext:', self.wmtContext);
                 } catch (e) {
@@ -148,6 +148,10 @@ impl Thread {
 
     pub fn terminate(&self) {
         self.atw_th.terminate();
+    }
+
+    pub fn is_terminated(&self) -> bool {
+        self.atw_th.is_terminated()
     }
 
     pub fn get_id(&self) -> Option<Rc<String>> {


### PR DESCRIPTION
Fixes #3. Slightly edited from the last iteration to remove unnecessary edits.

I didn't remove `is_terminated()` in `atw` and `thread` though.